### PR TITLE
Fix plugin meta information

### DIFF
--- a/admin-page.php
+++ b/admin-page.php
@@ -1,13 +1,13 @@
 <?php
 function sm_scheduler_admin_menu() {
     add_menu_page(
-        'Social Media Scheduler',
-        'Social Media Scheduler',
+        'Mars Share',
+        'Mars Share',
         'manage_options',
-        'social-media-scheduler',
+        'mars-share',
         'sm_scheduler_admin_page',
         'dashicons-share',
-        6
+        17
     );
 }
 add_action('admin_menu', 'sm_scheduler_admin_menu');
@@ -15,11 +15,11 @@ add_action('admin_menu', 'sm_scheduler_admin_menu');
 function sm_scheduler_admin_page() {
     ?>
 <div class="wrap">
-    <h2>Social Media Scheduler</h2>
+    <h2>Mars Share</h2>
     <form method="post" action="options.php">
         <?php
             settings_fields('sm_scheduler_options_group');
-            do_settings_sections('social-media-scheduler');
+            do_settings_sections('mars-share');
             submit_button();
             ?>
     </form>
@@ -31,16 +31,16 @@ function sm_scheduler_settings_init() {
     register_setting('sm_scheduler_options_group', 'sm_scheduler_options');
     add_settings_section(
         'sm_scheduler_section_developers',
-        __('Custom Settings', 'social-media-scheduler'),
+        __('Custom Settings', 'mars-share'),
         'sm_scheduler_section_callback',
-        'social-media-scheduler'
+        'mars-share'
     );
 
     add_settings_field(
         'sm_scheduler_custom_message',
-        __('Custom Message', 'social-media-scheduler'),
+        __('Custom Message', 'mars-share'),
         'sm_scheduler_custom_message_render',
-        'social-media-scheduler',
+        'mars-share',
         'sm_scheduler_section_developers'
     );
 }

--- a/mars-share.php
+++ b/mars-share.php
@@ -1,11 +1,11 @@
 <?php
 /*
-Plugin Name: Social Media Scheduler
-Plugin URI: http://yourwebsite.com/social-media-scheduler
+Plugin Name: Mars Share
+Plugin URI: https://www.uifrommars.com
 Description: Automatically share and schedule posts to social media with unique messages.
 Version: 1.0
-Author: Your Name
-Author URI: http://yourwebsite.com
+Author: Cris Busquets
+Author URI: http://www.cbusquets.com
 */
 
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );


### PR DESCRIPTION
* Update the plugin naming and meta information, so it uses "Mars Share" instead of "Social Media Sharer"
* Adds URL for the plugin, the author name and the author URL